### PR TITLE
Fix code scanning alert no. 2: Flask app is run in debug mode

### DIFF
--- a/src/modules/app.py
+++ b/src/modules/app.py
@@ -256,4 +256,5 @@ def product_comparison():
     
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    debug_mode = os.getenv('FLASK_DEBUG', 'False').lower() in ['true', '1', 't']
+    app.run(debug=debug_mode)


### PR DESCRIPTION
Fixes [https://github.com/se2024-jpg/Slash/security/code-scanning/2](https://github.com/se2024-jpg/Slash/security/code-scanning/2)

To fix the problem, we need to ensure that the Flask application does not run in debug mode in a production environment. The best way to achieve this is to control the debug mode based on an environment variable. This way, we can enable debug mode during development and disable it in production without changing the code.

1. Modify the `app.run()` method to check an environment variable (e.g., `FLASK_DEBUG`) to determine whether to run in debug mode.
2. Update the code to read the environment variable and set the `debug` parameter accordingly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
