### PR TITLE
Fix price fetch query for Walmart

### DIFF
--- a/src/modules/scraper.py
+++ b/src/modules/scraper.py
@@ -103,7 +103,7 @@ def searchWalmart(query, df_flag, currency):
     for res in results:
         titles, prices, links = (
             res.select("span.lh-title"),
-            res.select("div.lh-copy"),
+            res.select("div[data-automation-id='product-price']"),
             res.select("a"),
         )
         ratings = res.findAll("span", {"class": "w_iUH7"}, string=pattern)


### PR DESCRIPTION
Below change has been applied to scraper.py within searchWalmart function:

The price of products in Walmart is updated to fetch using the HTML tag "div[data-automation-id='product-price']"