### PR TITLE
Fix code scanning alert no. 11: Information exposure through an exception

### DIFF
--- a/src/modules/app.py
+++ b/src/modules/app.py
@@ -478,7 +478,7 @@ def delete_wishlist_item():
             return "Error removing item", 400
     except Exception as e:
         app.logger.error(f"Error removing item: {e}")
-        return jsonify(error=str(e)), 500
+        return jsonify(error="An internal error has occurred!"), 500
     
 @app.cli.command("init-db")
 def init_db():


### PR DESCRIPTION
Fixes [https://github.com/se2024-jpg/Slash/security/code-scanning/11](https://github.com/se2024-jpg/Slash/security/code-scanning/11)

To fix the problem, we should avoid returning the raw exception message to the user. Instead, we should log the detailed exception message on the server and return a generic error message to the user. This approach ensures that developers still have access to the detailed error information for debugging purposes, while users are not exposed to potentially sensitive information.

Specifically, we need to:
1. Modify the exception handling in the `delete_wishlist_item` function to log the exception message.
2. Return a generic error message to the user instead of the detailed exception message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
